### PR TITLE
ignore characters in front of the magic value

### DIFF
--- a/ltq-xdsl-fw-info.sh
+++ b/ltq-xdsl-fw-info.sh
@@ -202,7 +202,7 @@ done
 find "${FILEPATH}" -type f -print0 | while read -d $'\0' FILE
 do
 	FILENAME=$(basename "${FILE}")
-	VERSION_STRINGS=$(strings "${FILE}" | grep "@(#)")
+	VERSION_STRINGS=$(strings "${FILE}" | grep -o "@(#).*")
 	IFS=$'\n' read -d '' -r -a VERSIONS <<< "${VERSION_STRINGS//@(#)}"
 
 	case ${#VERSIONS[@]} in


### PR DESCRIPTION
fixes firmware platform extraction of FRITZ.Box_WLAN_3370.103.06.30.image.

Grep returns F!V2@(#)5.7.1.5.0.2 without this patch, which results in platform: 25.