### PR TITLE
Add firmware info from AVM FRITZ!Box 3370 version 103.06.30

### DIFF
--- a/_data/1bdbc95e0d394a1ec480170f71c46c0d10b302e7.yaml
+++ b/_data/1bdbc95e0d394a1ec480170f71c46c0d10b302e7.yaml
@@ -1,0 +1,33 @@
+downloads:
+    -
+        url: http://ftp.avm.de/fritz.box/fritzbox.wlan_3370/firmware/deutsch/FRITZ.Box_WLAN_3370.103.06.30.image
+        extractionsteps: >
+                <pre>
+                    7z e FRITZ.Box_WLAN_3370.103.06.30.image -r filesystem.image
+                    7z e filesystem.image filesystem_core.squashfs
+                    7z e filesystem_core.squashfs lib/modules/dsp_vr9/*
+                    
+                    bspatch vr9-B-dsl.bin vr9-A-dsl.bin vr9-A-dsl.bin.bsdiff
+                    bspatch vr9-A-dsl.bin release-vr9-A-dsl.bin release-vr9-A-dsl.bin.bsdiff
+                    md5sum -c release-vr9-A-dsl.bin.md5sum
+                </pre>
+filename: release-vr9-A-dsl.bin
+version: 5.6.7.3.1.7-5.6.1.E.1.1
+sha1sum: 1bdbc95e0d394a1ec480170f71c46c0d10b302e7
+filesize: 882932
+Firmware1:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 7
+    APPLICATION_TYPE_STR: VDSL over ISDN incl. vectoring support
+    VERSION_STR: 6.7.3
+    RELEASE_STATUS: 1
+    RELEASE_STATUS_STR: Pre-Release
+Firmware2:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 1
+    APPLICATION_TYPE_STR: ADSL Annex A
+    VERSION_STR: 6.1.E
+    RELEASE_STATUS: 1
+    RELEASE_STATUS_STR: Pre-Release

--- a/_data/3e3f074654e661c7821020d1583a942ae8a8d284.yaml
+++ b/_data/3e3f074654e661c7821020d1583a942ae8a8d284.yaml
@@ -1,0 +1,32 @@
+downloads:
+    -
+        url: http://ftp.avm.de/fritz.box/fritzbox.wlan_3370/firmware/deutsch/FRITZ.Box_WLAN_3370.103.06.30.image
+        extractionsteps: >
+                <pre>
+                    7z e FRITZ.Box_WLAN_3370.103.06.30.image -r filesystem.image
+                    7z e filesystem.image filesystem_core.squashfs
+                    7z e filesystem_core.squashfs lib/modules/dsp_vr9/*
+                    
+                    bspatch vr9-B-dsl.bin release-vr9-B-dsl.bin release-vr9-B-dsl.bin.bsdiff
+                    md5sum -c release-vr9-B-dsl.bin.md5sum
+                </pre>
+filename: release-vr9-B-dsl.bin
+version: 5.6.7.3.1.7-5.6.7.0.0.2
+sha1sum: 3e3f074654e661c7821020d1583a942ae8a8d284
+filesize: 865824
+Firmware1:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 7
+    APPLICATION_TYPE_STR: VDSL over ISDN incl. vectoring support
+    VERSION_STR: 6.7.3
+    RELEASE_STATUS: 1
+    RELEASE_STATUS_STR: Pre-Release
+Firmware2:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 2
+    APPLICATION_TYPE_STR: ADSL Annex B
+    VERSION_STR: 6.7.0
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release

--- a/_data/77a3e77a9f91a16e9edea4fb693b9d917c7b4c61.yaml
+++ b/_data/77a3e77a9f91a16e9edea4fb693b9d917c7b4c61.yaml
@@ -1,0 +1,32 @@
+downloads:
+    -
+        url: http://ftp.avm.de/fritz.box/fritzbox.wlan_3370/firmware/deutsch/FRITZ.Box_WLAN_3370.103.06.30.image
+        extractionsteps: >
+                <pre>
+                    7z e FRITZ.Box_WLAN_3370.103.06.30.image -r filesystem.image
+                    7z e filesystem.image filesystem_core.squashfs
+                    7z e filesystem_core.squashfs lib/modules/dsp_vr9/*
+                    
+                    bspatch vr9-B-dsl.bin vr9-A-dsl.bin vr9-A-dsl.bin.bsdiff
+                    md5sum -c vr9-A-dsl.bin.md5sum
+                </pre>
+filename: vr9-A-dsl.bin
+version: 5.7.4.4.1.7-5.7.1.8.0.1
+sha1sum: 77a3e77a9f91a16e9edea4fb693b9d917c7b4c61
+filesize: 900864
+Firmware1:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 7
+    APPLICATION_TYPE_STR: VDSL over ISDN incl. vectoring support
+    VERSION_STR: 7.4.4
+    RELEASE_STATUS: 1
+    RELEASE_STATUS_STR: Pre-Release
+Firmware2:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 1
+    APPLICATION_TYPE_STR: ADSL Annex A
+    VERSION_STR: 7.1.8
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release

--- a/_data/ae0a84f9a15ec3a036337b0e13d7a15ec141f76e.yaml
+++ b/_data/ae0a84f9a15ec3a036337b0e13d7a15ec141f76e.yaml
@@ -1,0 +1,29 @@
+downloads:
+    -
+        url: http://ftp.avm.de/fritz.box/fritzbox.wlan_3370/firmware/deutsch/FRITZ.Box_WLAN_3370.103.06.30.image
+        extractionsteps: >
+                <pre>
+                    7z e FRITZ.Box_WLAN_3370.103.06.30.image -r filesystem.image
+                    7z e filesystem.image filesystem_core.squashfs
+                    7z e filesystem_core.squashfs lib/modules/dsp_vr9/vr9-B-dsl.bin
+                </pre>
+filename: vr9-B-dsl.bin
+version: 5.7.4.4.1.7-5.7.1.5.0.2
+sha1sum: ae0a84f9a15ec3a036337b0e13d7a15ec141f76e
+filesize: 883552
+Firmware1:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 7
+    APPLICATION_TYPE_STR: VDSL over ISDN incl. vectoring support
+    VERSION_STR: 7.4.4
+    RELEASE_STATUS: 1
+    RELEASE_STATUS_STR: Pre-Release
+Firmware2:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 2
+    APPLICATION_TYPE_STR: ADSL Annex B
+    VERSION_STR: 7.1.5
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release


### PR DESCRIPTION
Includes the latest VDSL firmware found so far.