### PR TITLE
Add firmware info from Netgear DM200 version 1.0.0.34

### DIFF
--- a/_data/29de7210958de4ba57464685f680dd66e6fb5b36.yaml
+++ b/_data/29de7210958de4ba57464685f680dd66e6fb5b36.yaml
@@ -1,0 +1,31 @@
+downloads:
+    -
+        url: http://www.downloads.netgear.com/files/GDC/DM200/DM200_V1.0.0.34.zip
+        extractionsteps: >
+                <pre>
+                    7z e DM200_V1.0.0.34.zip
+                    7z e DM200-V1.0.0.34.img dsl_vr9_firmware_xdsl-05.08.01.05.00.07_05.08.00.09.00.01.bin
+                </pre>
+
+                NOTE: p7zip version 15.09 or newer is required to extract the images.
+filename: dsl_vr9_firmware_xdsl-05.08.01.05.00.07_05.08.00.09.00.01.bin
+version: 5.8.1.5.0.7-5.8.0.9.0.1
+sha1sum: 29de7210958de4ba57464685f680dd66e6fb5b36
+filesize: 898856
+Firmware1:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 7
+    APPLICATION_TYPE_STR: VDSL over ISDN incl. vectoring support
+    VERSION_STR: 8.1.5
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release
+Firmware2:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 1
+    APPLICATION_TYPE_STR: ADSL Annex A
+    VERSION_STR: 8.0.9
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release
+

--- a/_data/77f69e99cd0e0d4d58454880a21438543f1571dc.yaml
+++ b/_data/77f69e99cd0e0d4d58454880a21438543f1571dc.yaml
@@ -1,0 +1,31 @@
+downloads:
+    -
+        url: http://www.downloads.netgear.com/files/GDC/DM200/DM200_V1.0.0.34.zip
+        extractionsteps: >
+                <pre>
+                    7z e DM200_V1.0.0.34.zip
+                    7z e DM200-V1.0.0.34.img dsl_vr9_firmware_xdsl-05.07.06.0A.00.07_05.07.01.0C.00.02.bin
+                </pre>
+
+                NOTE: p7zip version 15.09 or newer is required to extract the images.
+filename: dsl_vr9_firmware_xdsl-05.07.06.0A.00.07_05.07.01.0C.00.02.bin
+version: 5.7.6.A.0.7-5.7.1.C.0.2
+sha1sum: 77f69e99cd0e0d4d58454880a21438543f1571dc
+filesize: 909548
+Firmware1:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 7
+    APPLICATION_TYPE_STR: VDSL over ISDN incl. vectoring support
+    VERSION_STR: 7.6.A
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release
+Firmware2:
+    PLATFORM: 5
+    PLATFORM_STR: VRX200
+    APPLICATION_TYPE: 2
+    APPLICATION_TYPE_STR: ADSL Annex B
+    VERSION_STR: 7.1.C
+    RELEASE_STATUS: 0
+    RELEASE_STATUS_STR: Release
+


### PR DESCRIPTION
Beside the ADSL Annex B firmware these are the most recent versions so far.